### PR TITLE
feat: add dev environment for default namespace (fixes #23)

### DIFF
--- a/.sourceignore
+++ b/.sourceignore
@@ -1,1 +1,2 @@
 .github/
+dev/**/

--- a/default/minecraft/kustomization.yaml
+++ b/default/minecraft/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./minecraft-creative.yaml
+  - ./minecraft-database.yaml
+  - ./minecraft-proxy-bravo.yaml
+  - ./minecraft-survival.yaml

--- a/default/minecraft/minecraft-survival.yaml
+++ b/default/minecraft/minecraft-survival.yaml
@@ -3,7 +3,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: minecraft-survival
-  namespace: default
 spec:
   interval: 5m
   install:

--- a/dev/default/minecraft-creative.yaml
+++ b/dev/default/minecraft-creative.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: minecraft-creative
+spec:
+  values:
+    persistence:
+      dataDir:
+        size: 1Gi
+    resources:
+      requests:
+        memory: 1024Mi
+      limits:
+        memory: 2048Mi
+    minecraftServer:
+      memory: 1G

--- a/dev/default/minecraft-proxy-bravo.yaml
+++ b/dev/default/minecraft-proxy-bravo.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: minecraft-proxy-bravo
+spec:
+  values:
+    bungeeCord:
+      loadBalancerIP: 138.201.203.147
+      memory: 512M

--- a/dev/default/minecraft-survival.yaml
+++ b/dev/default/minecraft-survival.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: minecraft-survival
+spec:
+  values:
+    persistence:
+      dataDir:
+        size: 1Gi
+    resources:
+      requests:
+        memory: 1024Mi
+      limits:
+        memory: 2048Mi
+    minecraftServer:
+      memory: 1G

--- a/dev/kustomization.yaml
+++ b/dev/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dev
+resources:
+  - ../default
+patchesStrategicMerge:
+  - ./default/minecraft-creative.yaml
+  - ./default/minecraft-proxy-bravo.yaml
+  - ./default/minecraft-survival.yaml

--- a/dev/namespace.yaml
+++ b/dev/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/flux-system/gotk-sync.yaml
+++ b/flux-system/gotk-sync.yaml
@@ -11,6 +11,27 @@ spec:
   secretRef:
     name: flux-system
   url: ssh://git@github.com/architectsmp/k8s-gitops
+  ignore: |
+    # exclude dev directory
+    /dev/
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: flux-system-dev
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: dev
+  secretRef:
+    name: flux-system
+  url: ssh://git@github.com/architectsmp/k8s-gitops
+  ignore: |
+    # exclude all
+    /*
+    # include dev directory
+    !/dev/
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
This change adds an additional namespace `dev`.
It also instructs Flux to only pick up changes to the `dev` namespace from the `dev` branch.

Kustomize uses the existing deployments in the `default` namespace as a 'base', so any changes to the `default` namespace in the `dev` branch will only affect the `dev` namespace. There are some patches in the `dev` folder to reduce memory/volume usage.

**There is a potential that merging this PR will reboot the servers, so please warn the users in case it does**.