### PR TITLE
fix(proxy,nginx): swap alpha & charlie load balancer ips

### DIFF
--- a/default/minecraft/minecraft-proxy-bravo.yaml
+++ b/default/minecraft/minecraft-proxy-bravo.yaml
@@ -24,7 +24,7 @@ spec:
     bungeeCord:
       type: WATERFALL
       serviceType: LoadBalancer
-      loadBalancerIP: 138.201.203.147
+      loadBalancerIP: 138.201.203.183
       externalTrafficPolicy: Local
       memory: 2G
       rcon:

--- a/kube-system/nginx/nginx.yaml
+++ b/kube-system/nginx/nginx.yaml
@@ -24,7 +24,7 @@ spec:
         hsts-max-age: "31449600"
       use-forwarded-headers: "true"
       service:
-        loadBalancerIP: 138.201.203.183
+        loadBalancerIP: 138.201.203.147
         externalTrafficPolicy: Local
       metrics:
         enabled: true


### PR DESCRIPTION
_This is a likely fix for #25._

**Warning**: the `proxy.architectsmp.com` CNAME must be repointed to `charlie.de.artemis.architectsmp.com` **AND** the `map.architectsmp.com` CNAME must be repointed to `alpha.de.artemis.architectsmp.com` **BEFORE** merging this PR.

Once this change is merged, the main proxy should not restart but players _may_ be disconnected and will need to wait 5 minutes & relaunch the game to log back in.
Any other DNS issues reported should be referred to [1.1.1.1](https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1).