### PR TITLE
chore(ci/renovate): add schedule, dashboard autoclose, and automerge (fixes #34)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,9 @@
 {
   enabled: true,
   timezone: "UTC",
+  schedule: "after 5pm and before 10pm",
   dependencyDashboard: true,
-  dependencyDashboardTitle: "Renovate Dashboard",
+  dependencyDashboardAutoclose: true,
   commitMessageSuffix: "[ci-skip]",
   commitBody: "Signed-off-by: Architect SMP <bloodycoffin@users.noreply.github.com>",
   // Do not notify on closed unmerged PRs
@@ -40,6 +41,24 @@
       updateTypes: ["major", "minor", "patch"],
       enabled: true,
       separateMinorPatch: true,
+    },
+    // Automerge updates
+    {
+      packageRules: [
+        {
+          matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+          automerge: true,
+          automergeType: "branch",
+        },
+      ],
+    },
+    {
+      packageRules: [
+        {
+          matchPackagePatterns: ["^minecraft"],
+          automerge: false,
+        },
+      ],
     },
     // Add labels according to package and update types
     {


### PR DESCRIPTION
This change will:
- Enable auto-merging of non-major updates to helm charts and containers _(except those which are directly related to Minecraft which will still need approvals)_
- Renovate will now only run between 5 and 10pm UTC to ensure we are online in the event of any issues
- The `Renovate Dashboard` issue will automatically close when there are no pending updates