### PR TITLE
feat: add velero (fix #41)

### DIFF
--- a/flux-system-extras/helm-chart-repositories/vmware-tanzu-charts.yaml
+++ b/flux-system-extras/helm-chart-repositories/vmware-tanzu-charts.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: vmware-tanzu-charts
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: https://vmware-tanzu.github.io/helm-charts
+  timeout: 3m

--- a/velero/README.md
+++ b/velero/README.md
@@ -1,0 +1,23 @@
+# velero
+
+![](https://i.imgur.com/feo6EpE.png)
+
+[Velero](https://velero.io/) is a cluster backup & restore solution.  I can also leverage restic to backup persistent volumes to S3 storage buckets.
+
+* [velero](velero/)
+* [rules/velero.yaml](rules/velero.yaml) - Prometheus alertmanager rules for Velero
+* [change-storage-class-config.yaml](change-storage-class-config.yaml) - (disabled) example ConfigMap demonstrating how to restore from one storage class type to a different storage class type
+
+## Restore Process
+
+In order to restore a given workload, the follow steps should work:
+
+1. A backup should already be created either via:
+   * a global backup (e.g. a scheduled backup), 
+   * or via a backup created using a label selector (that's present on the deployment, pv, & pvc) for the application, e.g. `velero backup create test-minecraft --selector "app=mc-test-minecraft" --wait`
+1. <Do whatever action results in the active data getting lost (e.g. `kubectl delete hr mc-test`)>
+1. Delete the unwanted new data & associate Deployment/StatefulSet/Daemonset, e.g. `kubectl delete deployment mc-test-minecraft && kubectl delete pvc mc-test-minecraft-datadir`
+1. Restore from restic the backup with only the label selector, e.g. `velero restore create --from-backup test-minecraft --selector "app=mc-test-minecraft" --wait`
+
+* This should not interfere with the HelmRelease or require scaling helm-operator
+* You don't need to worry about adding labels to the HelmRelease or backing-up the helm secret object

--- a/velero/change-storage-class-config.yaml
+++ b/velero/change-storage-class-config.yaml
@@ -1,0 +1,22 @@
+# apiVersion: v1
+# kind: ConfigMap
+# metadata:
+#   # any name can be used; Velero uses the labels (below)
+#   # to identify it rather than the name
+#   name: change-storage-class-config
+#   # must be in the velero namespace
+#   namespace: velero
+#   # the below labels should be used verbatim in your
+#   # ConfigMap.
+#   labels:
+#     # this value-less label identifies the ConfigMap as
+#     # config for a plugin (i.e. the built-in restore item action plugin)
+#     velero.io/plugin-config: ""
+#     # this label identifies the name and kind of plugin
+#     # that this ConfigMap is for.
+#     velero.io/change-storage-class: RestoreItemAction
+# data:
+#   # add 1+ key-value pairs here, where the key is the old
+#   # storage class name and the value is the new storage
+#   # class name.
+#   nfs-client: rook-ceph-block

--- a/velero/namespace.yaml
+++ b/velero/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero

--- a/velero/velero/velero-helm-values.txt
+++ b/velero/velero/velero-helm-values.txt
@@ -1,0 +1,6 @@
+credentials:
+  secretContents:
+    cloud: |
+      [default]
+      aws_access_key_id = $MINIO_ACCESS_KEY
+      aws_secret_access_key = $MINIO_SECRET_KEY

--- a/velero/velero/velero.yaml
+++ b/velero/velero/velero.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: velero
+  namespace: velero
+spec:
+  interval: 5m
+  chart:
+    spec:
+      # renovate: registryUrl=https://vmware-tanzu.github.io/helm-charts
+      chart: velero
+      version: 2.14.8
+      sourceRef:
+        kind: HelmRepository
+        name: vmware-tanzu-charts
+        namespace: flux-system
+      interval: 5m
+  values:
+    image:
+      repository: velero/velero
+      tag: v1.5.3
+    configuration:
+      provider: aws
+      backupStorageLocation:
+        name: default
+        bucket: velero
+        config:
+          region: us-east-1
+          s3ForcePathStyle: true
+          s3Url: http://minio.monitoring.svc:9000
+          publicUrl: https://minio.architectsmp.com
+      volumeSnapshotLocation:
+        name: aws
+        config:
+          region: us-east-1
+      resticTimeout: 6h
+    initContainers:
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:v1.1.0
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - mountPath: /target
+            name: plugins
+    resources:
+      requests:
+        memory: 300Mi
+        cpu: 25m
+      limits:
+        memory: 1500Mi
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    snapshotsEnabled: true
+    deployRestic: true
+    installCRDs: true
+    restic:
+      podVolumePath: /var/lib/kubelet/pods
+      privileged: false
+      tolerations:
+        - key: "arm"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+      resources:
+        requests:
+          memory: 200Mi
+          cpu: 15m
+        limits:
+          memory: 2000Mi
+    schedules:
+      daily-backup:
+        schedule: "0 6 * * *"
+        template:
+          ttl: "120h"
+      minecraft-survival-minecraft-hourly:
+        schedule: "0 * * * *"
+        template:
+          labelSelector:
+            matchLabels:
+              app: minecraft-survival-minecraft
+          ttl: "120h"
+          includedNamespaces:
+            - default
+      minecraft-survival-minecraft-hourly:
+        schedule: "0 * * * *"
+        template:
+          labelSelector:
+            matchLabels:
+              app: minecraft-survival-minecraft
+          ttl: "120h"
+          includedNamespaces:
+            - default
+  valuesFrom:
+    - kind: Secret
+      name: "velero-helm-values"
+      optional: false


### PR DESCRIPTION
This adds the backup mechanism for volumes in the cluster, this is part 1/3 of fixes required for #41.
The next steps are adding a Hetzner storage box for `minio` to persist data to and moving from `local-path` to `rook-ceph`.