### PR TITLE
fix(dev/survival): disable dynmap ingress

### DIFF
--- a/dev/minecraft-survival.yaml
+++ b/dev/minecraft-survival.yaml
@@ -15,3 +15,6 @@ spec:
         memory: 2048Mi
     minecraftServer:
       memory: 1G
+      dynmap:
+        ingress:
+          enabled: false


### PR DESCRIPTION
The dynmap ingress is attempting to deploy in the dev environment which is conflicting with the main environment. This change disables it as we don't currently test dynmap in dev.