### PR TITLE
chore(minecraft/proxy): use itzg helm repository

### DIFF
--- a/default/minecraft/minecraft-creative.yaml
+++ b/default/minecraft/minecraft-creative.yaml
@@ -27,7 +27,7 @@ spec:
     image: itzg/minecraft-server
     imageTag: 1.8.0-adopt13
     persistence:
-      storageClass: local-path
+      storageClass: openebs-hostpath
       dataDir:
         enabled: true
         size: 10Gi

--- a/default/minecraft/minecraft-database.yaml
+++ b/default/minecraft/minecraft-database.yaml
@@ -32,5 +32,5 @@ spec:
     primary:
       persistence:
         enabled: true
-        storageClass: local-path
+        storageClass: openebs-hostpath
         size: 8Gi

--- a/default/minecraft/minecraft-proxy-bravo.yaml
+++ b/default/minecraft/minecraft-proxy-bravo.yaml
@@ -24,7 +24,7 @@ spec:
     image: itzg/bungeecord
     imageTag: 1.5.0-adopt13
     persistence:
-      storageClass: local-path
+      storageClass: openebs-hostpath
       dataDir:
         enabled: true
     bungeeCord:

--- a/default/minecraft/minecraft-survival.yaml
+++ b/default/minecraft/minecraft-survival.yaml
@@ -26,7 +26,7 @@ spec:
     image: itzg/minecraft-server
     imageTag: 1.8.0-adopt13
     persistence:
-      storageClass: local-path
+      storageClass: openebs-hostpath
       dataDir:
         enabled: true
         size: 10Gi

--- a/kube-system/openebs/helm-release.yaml
+++ b/kube-system/openebs/helm-release.yaml
@@ -18,9 +18,9 @@ spec:
   values:
     # required only for cStor & Jiva
     apiserver:
-      enabled: false
+      enabled: true
     provisioner:
       enabled: false
     # openebs/openebs#3046
     webhook:
-      failurePolicy: "Ignore"
+      failurePolicy: Ignore

--- a/kube-system/openebs/helm-release.yaml
+++ b/kube-system/openebs/helm-release.yaml
@@ -21,7 +21,6 @@ spec:
       enabled: false
     provisioner:
       enabled: false
-    ndm:
-      enabled: false
-    ndmOperator:
-      enabled: false
+    # openebs/openebs#3046
+    webhook:
+      failurePolicy: "Ignore"


### PR DESCRIPTION
[ArchitectSMP/charts](https://github.com/architectsmp/charts) is now deprecated, the chart has been contributed upstream to [itzg/minecraft-server-charts](https://github.com/itzg/minecraft-server-charts).

As the chart for the proxy service [is now in a new home](itzg/minecraft-server-charts#50), this change swaps the Helm repository we use for our proxy deployment.
